### PR TITLE
Rimuove chiavi non presenti in lingua originale da Accounts.php

### DIFF
--- a/modules/Accounts.php
+++ b/modules/Accounts.php
@@ -40,10 +40,6 @@ $languageStrings = array(
 	'SINGLE_Accounts'              => 'Organizzazione'              , 
 	'Ticker Symbol'                => 'Simbolo ticker'              , 
 	'Website'                      => 'Sito web'                    , 
-	
-	//
-	'New This Week'                => 'Di questa settimana'         , 
-	'Prospect Accounts'            => 'Prospetti'                   , 	
 );
 
 $jsLanguageStrings = array(


### PR DESCRIPTION
Ho creato uno script che effettua un controllo incrociato tra le chiavi della traduzione e quelle dei testi originali (sto usando en_us come riferimento).
Lo si può trovare qui: https://gist.github.com/lucasaba/d0633ca133d24d2f8f72
Piano piano faccio un po di pulizia.
